### PR TITLE
Add little delay to make sure the client gets the success message

### DIFF
--- a/wifimgr.py
+++ b/wifimgr.py
@@ -214,6 +214,9 @@ def handle_configure(client, request):
             profiles = {}
         profiles[ssid] = password
         write_profiles(profiles)
+
+        time.sleep(5)
+
         return True
     else:
         response = """\
@@ -290,4 +293,3 @@ def start(port=80):
                 handle_not_found(client, url)
         finally:
             client.close()
-            


### PR DESCRIPTION
It can happen that the sockets closes before the client got the success massage, this makes sure that this doesn't happen or at least makes it far less likely to happen.